### PR TITLE
Fix VitePress build: Correct all dead links

### DIFF
--- a/docs/10-backup/1-restic-system-backup.md
+++ b/docs/10-backup/1-restic-system-backup.md
@@ -92,9 +92,9 @@ graph TB
 
 ## Prerequisites
 
-> [!NOTE] 🏠 Minio S3 Backend Required*  
-> This guide assumes you have already configured Minio S3 storage as described in:  
-> [Minio S3 Backup Backend Setup](../../3-external-services/1-s3-backup-backend-minio-setup.md)
+> [!NOTE] 🏠 Minio S3 Backend Required*
+> This guide assumes you have already configured Minio S3 storage as described in:
+> [Minio S3 Backup Backend Setup](../3-external-services/1-s3-backup-backend-minio-setup)
 >
 > Required components:
 >

--- a/docs/2-cluster-setup/1-cluster-gateway-configuration.md
+++ b/docs/2-cluster-setup/1-cluster-gateway-configuration.md
@@ -1371,7 +1371,6 @@ ntp_config:
 This comprehensive gateway configuration provides enterprise-grade network infrastructure for your PiKube Kubernetes cluster. The combination of advanced firewall protection, intelligent DNS/DHCP management, and high-precision time synchronization creates a robust foundation for reliable cluster operations.
 
 For related configurations, see:
-- [PiKube DNS Architecture](./3-pikube-dns-architecture.md)
-- [Kubernetes Cluster Setup](./2-kubernetes-cluster-setup.md)
+- [PiKube DNS Architecture](./3-dns-architecture)
 
 *Documentation based on live system analysis and professional network engineering practices.*

--- a/docs/2-cluster-setup/3-dns-architecture.md
+++ b/docs/2-cluster-setup/3-dns-architecture.md
@@ -355,7 +355,7 @@ Deploy ExternalDNS in your Kubernetes cluster to automatically manage DNS record
 
 > [!IMPORTANT]📋 Implementation Details  
 > For complete CoreDNS and ExternalDNS configuration, deployment steps, and troubleshooting, see:  
-> [Kubernetes DNS with CoreDNS and External-DNS](../5-networking/6-dns-coredns-and-external-dns-kubernetes-revised.md)
+> [Kubernetes DNS with CoreDNS and External-DNS](../5-networking/6-dns-coredns-and-external-dns-kubernetes.md)
 
 ---
 
@@ -382,6 +382,6 @@ Deploy ExternalDNS in your Kubernetes cluster to automatically manage DNS record
 
 This architecture provides the foundation for a production-ready, secure, and scalable DNS infrastructure that grows with your Kubernetes cluster while maintaining the flexibility to access services from both internal and external networks.
 
-For implementation details about Kubernetes DNS services, see [Kubernetes DNS with CoreDNS and External-DNS](../5-networking/6-dns-coredns-and-external-dns-kubernetes-revised.md).
+For implementation details about Kubernetes DNS services, see [Kubernetes DNS with CoreDNS and External-DNS](../5-networking/6-dns-coredns-and-external-dns-kubernetes.md).
 
 Zone file syntax follows [RFC1035](https://datatracker.ietf.org/doc/html/rfc1035) standards. For detailed zone file structure information, see [Bind9 documentation](https://bind9.readthedocs.io/en/v9.18.30/chapter3.html#soa-rr).

--- a/docs/5-networking/6-dns-coredns-and-external-dns-kubernetes.md
+++ b/docs/5-networking/6-dns-coredns-and-external-dns-kubernetes.md
@@ -13,7 +13,7 @@ Kubernetes DNS services form the backbone of service discovery and external conn
 
 > [!IMPORTANT] 🏠 DNS Architecture Foundation
 > This guide assumes you have already implemented the split-horizon DNS architecture described in:  
-> [PiKube Split-Horizon DNS Architecture](../../2-cluster-setup/3-dns-architecture.md)
+> [PiKube Split-Horizon DNS Architecture](../2-cluster-setup/3-dns-architecture)
 >
 > The foundation includes:
 >
@@ -269,7 +269,7 @@ External-DNS automatically synchronizes Kubernetes services with external DNS pr
 
 > [!IMPORTANT] 📋 Foundation Required  
 > This section assumes you have already completed the Bind9 setup from:  
-> [PiKube Split-Horizon DNS Architecture - Step 1](../../2-cluster-setup/3-dns-architecture.md#step-1-internal-authoritative-dns-server-setup)
+> [PiKube Split-Horizon DNS Architecture - Step 1](../2-cluster-setup/3-dns-architecture#step-1-internal-authoritative-dns-server-setup)
 >
 > If you haven't completed the basic setup, please do so before proceeding.
 
@@ -288,7 +288,7 @@ grep -q "include.*externaldns.key" /etc/bind/named.conf && echo "TSIG key includ
 sudo named-checkconf
 ```
 
-If the TSIG key is missing, follow the [DNS Architecture Setup Guide](../../2-cluster-setup/3-dns-architecture.md#security-configuration) to generate and configure it.
+If the TSIG key is missing, follow the [DNS Architecture Setup Guide](../2-cluster-setup/3-dns-architecture#security-configuration) to generate and configure it.
 
 ### External-DNS Installation
 


### PR DESCRIPTION
- Fix relative paths (use ../ instead of ../../ for sibling directories)
- Remove .md extensions from internal links (VitePress convention)
- Update backup doc to reference correct minio setup path
- Update DNS architecture cross-references
- Update gateway configuration links

All dead links resolved, build now passes successfully.